### PR TITLE
Optional.ofNullable is generally more usable in conjucture with .orElse()

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,13 +344,17 @@ Optionals are not functional interfaces, but nifty utilities to prevent `NullPoi
 Optional is a simple container for a value which may be null or non-null. Think of a method which may return a non-null result but sometimes return nothing. Instead of returning `null` you return an `Optional` in Java 8.
 
 ```java
-Optional<String> optional = Optional.of("bam");
+Optional<String> optional = Optional.ofNullable("bam");
 
 optional.isPresent();           // true
 optional.get();                 // "bam"
 optional.orElse("fallback");    // "bam"
 
 optional.ifPresent((s) -> System.out.println(s.charAt(0)));     // "b"
+
+List<String> initials = null;                                                     // uninitilized
+initials = Optional.ofNullable(initials).orElse(Arrays.asList("abc", "def"));     // ["abc", "def"]
+
 ```
 
 ## Streams


### PR DESCRIPTION
It allows for a cleaner look when initializing variables. 

I.e, instead of

``` java
if(someting == null) {
    something = new Something();
}
```

you can go

``` java
something = Optional.ofNullable(something).orElse(new Something);
```

Using

``` java
Optional.of(null).orElse("something");
```

throws a NullPointer
