### PR TITLE
Use class instead of bean.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ String converted = converter.convert("Java");
 System.out.println(converted);    // "J"
 ```
 
-Let's see how the `::` keyword works for constructors. First we define an example bean with different constructors:
+Let's see how the `::` keyword works for constructors. First we define an example class with different constructors:
 
 ```java
 class Person {


### PR DESCRIPTION
A class should only be called 'bean', if:

* all properties are private (use getters/setters)
* it implements the Serializable interface
* it has a public default constructor

See: http://stackoverflow.com/questions/3295496/what-is-a-javabean-exactly